### PR TITLE
Change lexicons localizator_key_yandex, default_translator_desc

### DIFF
--- a/core/components/localizator/lexicon/en/setting.inc.php
+++ b/core/components/localizator/lexicon/en/setting.inc.php
@@ -7,10 +7,10 @@ $_lang['setting_localizator_default_language'] = 'The default localization key';
 $_lang['setting_localizator_default_language_desc'] = 'Key localization for primary language version';
 
 $_lang['setting_localizator_key_yandex'] = 'API key for Yandex';
-$_lang['setting_localizator_key_yandex_desc'] = 'API key for Yandex translator, https://translate.yandex.ru/developers/keys';
+$_lang['setting_localizator_key_yandex_desc'] = 'API key for Yandex translator, <a href="https://tech.yandex.ru/keys/get/?service=trnsl" target="_blank">API key</a>';
 
 $_lang['setting_localizator_default_translator'] = 'Translator automatic translation';
-$_lang['setting_localizator_key_yandex_desc'] = 'So far available only to Yandex';
+$_lang['setting_localizator_default_translator_desc'] = 'So far available only to Yandex';
 
 $_lang['setting_localizator_translate_translated'] = 'Complement translated localization?';
 $_lang['setting_localizator_translate_translated_desc'] = 'When you use automatic translation translate blank fields from existing localisations';

--- a/core/components/localizator/lexicon/fr/setting.inc.php
+++ b/core/components/localizator/lexicon/fr/setting.inc.php
@@ -7,10 +7,10 @@ $_lang['setting_localizator_default_language'] = 'La clé de localisation par d�
 $_lang['setting_localizator_default_language_desc'] = 'Localisation de clé pour la version de langue principale';
 
 $_lang['setting_localizator_key_yandex'] = 'Clé d’API pour Yandex';
-$_lang['setting_localizator_key_yandex_desc'] = 'Clé d’API pour Yandex traducteur, https://translate.yandex.ru/developers/keys';
+$_lang['setting_localizator_key_yandex_desc'] = 'Clé d’API pour Yandex traducteur, <a href="https://tech.yandex.ru/keys/get/?service=trnsl" target="_blank">Clé d’API</a>';
 
 $_lang['setting_localizator_default_translator'] = 'Traduction automatique de traducteur';
-$_lang['setting_localizator_key_yandex_desc'] = 'Jusqu\'à présent disponible uniquement pour Yandex';
+$_lang['setting_localizator_default_translator_desc'] = 'Jusqu\'à présent disponible uniquement pour Yandex';
 
 $_lang['setting_localizator_translate_translated'] = 'Localisation de complément traduit ?';
 $_lang['setting_localizator_translate_translated_desc'] = 'Lorsque vous utilisez automatique traduction traduire les champs vides de localisations existantes';

--- a/core/components/localizator/lexicon/ru/setting.inc.php
+++ b/core/components/localizator/lexicon/ru/setting.inc.php
@@ -7,10 +7,10 @@ $_lang['setting_localizator_default_language'] = 'Ключ локализаци�
 $_lang['setting_localizator_default_language_desc'] = 'Ключ локализации для основной языковой версии';
 
 $_lang['setting_localizator_key_yandex'] = 'API ключ для Яндекс';
-$_lang['setting_localizator_key_yandex_desc'] = 'API ключ для Яндекс переводчика, https://translate.yandex.ru/developers/keys';
+$_lang['setting_localizator_key_yandex_desc'] = 'API ключ для Яндекс переводчика, <a href="https://tech.yandex.ru/keys/get/?service=trnsl" target="_blank">API ключ</a>';
 
 $_lang['setting_localizator_default_translator'] = 'Переводчик для автоматического перевода';
-$_lang['setting_localizator_key_yandex_desc'] = 'Пока что доступен только Yandex';
+$_lang['setting_localizator_default_translator_desc'] = 'Пока что доступен только Yandex';
 
 $_lang['setting_localizator_translate_translated'] = 'Дополнять переведенные локализации?';
 $_lang['setting_localizator_translate_translated_desc'] = 'При использовании автоматического перевода переведет ПУСТЫЕ поля у существующих локализаций';


### PR DESCRIPTION
Исправлено дублирование описания в лексиконах `setting_localizator_key_yandex_desc ` 
Изменено описание для лексикона `setting_localizator_default_translator_desc`