### PR TITLE
Release 1.1.0-beta: fixes for issues #3, #4, #5, #6, #7

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -5,7 +5,7 @@
 define('PKG_NAME', 'localizator');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '1.0.9');
+define('PKG_VERSION', '1.1.0');
 define('PKG_RELEASE', 'beta');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -15,6 +15,11 @@ $tmp = array(
         'value' => false,
         'area' => 'localizator_main',
     ),
+    'disabled_templates' => array(
+        'xtype' => 'textfield',
+        'value' => '',
+        'area' => 'localizator_main',
+    ),
 
     // translator
     'default_translator' => array(

--- a/assets/components/localizator/js/mgr/widgets/content.grid.js
+++ b/assets/components/localizator/js/mgr/widgets/content.grid.js
@@ -438,7 +438,6 @@ Ext.extend(MODx.window.UpdatLocalizatorItem,Ext.Window,{
             ,baseParams: this.config.baseParams || { action: this.config.action || '' }
             //,items: this.config.fields || []
         });
-		//console.log('renderForm');
         this.add(this.fp);
     }	
     ,createForm: function(config){

--- a/core/components/localizator/docs/changelog.txt
+++ b/core/components/localizator/docs/changelog.txt
@@ -1,6 +1,14 @@
 Changelog for localizator.
 
 
+1.1.0-beta
+==============
+- Fixed wrong language key when editing title from grid (issue #6): key is now taken from [key] in display value
+- Removed console.log from content grid (issue #7)
+- Added system setting "Disable localization tab for templates" and plugin support (issue #5): comma-separated template IDs hide the Localizator tab
+- Fixed modWebLink/modSymLink content field (issue #4): field is shown in localization form and per-language link target is saved correctly; default language only is updated on resource save
+- Fixed duplicate path in TV when outputting via Fenom {$resource.tvName} (issue #3): LocalizatorResourceTVWrapper prevents double application of TV output (e.g. image basePath)
+
 1.0.9-beta
 ==============
 - Moved yandex translator in custom class

--- a/core/components/localizator/elements/plugins/plugin.localizator.php
+++ b/core/components/localizator/elements/plugins/plugin.localizator.php
@@ -25,6 +25,11 @@ switch ($modx->event->name) {
         break;
     case 'OnDocFormPrerender':
         if ($mode == 'upd' && $resource instanceof modResource) {
+            $disabledTemplates = $modx->getOption('localizator_disabled_templates', null, '', true);
+            $disabledTemplates = array_map('trim', array_filter(explode(',', $disabledTemplates)));
+            if (in_array((string)$resource->get('template'), $disabledTemplates, true)) {
+                break;
+            }
             $modx->controller->addLexiconTopic('localizator:default');
             $modx->controller->addCss($localizator->config['cssUrl'] . 'mgr/main.css');
             $modx->controller->addCss($localizator->config['cssUrl'] . 'mgr/bootstrap.buttons.css');
@@ -100,6 +105,7 @@ switch ($modx->event->name) {
         break;
 
     case 'OnLoadWebDocument':
+        require_once $localizator->config['modelPath'] . 'localizator/localizatorresourcetvwrapper.class.php';
         $q = $modx->newQuery('localizatorContent');
         $q->leftJoin('localizatorLanguage', 'localizatorLanguage', 'localizatorLanguage.key = localizatorContent.key');
         $q->where(array(
@@ -123,18 +129,18 @@ switch ($modx->event->name) {
                     $modx->resource->set($field, $value);
                 }
             }
+            $localizatorTVOutput = array();
             foreach ($content->getTVKeys() as $field) {
                 $value = $content->get($field);
                 if (!empty($value)) {
                     $value = localizatorContent::renderTVOutput($modx, $field, $value, $modx->resource->id);
-                    $modx->resource->_fieldMeta[$field] = [
-                        'dbtype' => 'mediumtext',
-                        'phptype' => 'string',
-                    ];
-
-                    $placeholders[$field] = $value;
                     $modx->resource->set($field, $value);
+                    $localizatorTVOutput[$field] = $value;
+                    $placeholders[$field] = $value;
                 }
+            }
+            if (!empty($localizatorTVOutput)) {
+                $modx->resource = new LocalizatorResourceTVWrapper($modx->resource, $localizatorTVOutput);
             }
             $modx->setPlaceholders($placeholders, '*');
         }
@@ -169,9 +175,15 @@ switch ($modx->event->name) {
                     $content->save();
                 }
             }
-        } elseif (in_array($resource->get('class_key'), array('modStaticResource', 'modSymLink', 'modWebLink'))) {
+        } elseif ($resource->get('class_key') === 'modStaticResource') {
             $upd = $modx->prepare("UPDATE " . $modx->getTableName('localizatorContent') . " SET `content` = ? WHERE `resource_id` = ?");
             $upd->execute(array($resource->get('content'), $resource->get('id')));
+        } elseif (in_array($resource->get('class_key'), array('modSymLink', 'modWebLink'))) {
+            $defaultKey = $modx->getOption('localizator_default_language', null, '', true);
+            if ($defaultKey !== '') {
+                $upd = $modx->prepare("UPDATE " . $modx->getTableName('localizatorContent') . " SET `content` = ? WHERE `resource_id` = ? AND `key` = ?");
+                $upd->execute(array($resource->get('content'), $resource->get('id'), $defaultKey));
+            }
         }
         break;
 

--- a/core/components/localizator/lexicon/be/setting.inc.php
+++ b/core/components/localizator/lexicon/be/setting.inc.php
@@ -23,3 +23,6 @@ $_lang['setting_localizator_translate_fields_desc'] = 'Гэтыя палі бу�
 
 $_lang['setting_localizator_tv_fields'] = 'Спіс дадатковых палёў (ТБ)';
 $_lang['setting_localizator_tv_fields_desc'] = 'Гэтыя дадатковыя поля будуць даступныя для рэдагавання ў лакалізацыі. Пакіньце гэты параметр пустым, калі вам патрэбныя ўсе дадатковыя поля';
+
+$_lang['setting_localizator_disabled_templates'] = 'Адключыць укладку лакалізацыі для шаблонаў';
+$_lang['setting_localizator_disabled_templates_desc'] = 'Пералік ID шаблонаў праз коску. Для рэсурсаў з гэтымі шаблонамі укладка «Лакалізатар» не будзе адлюстроўвацца.';

--- a/core/components/localizator/lexicon/en/setting.inc.php
+++ b/core/components/localizator/lexicon/en/setting.inc.php
@@ -32,3 +32,6 @@ $_lang['setting_localizator_tv_fields_desc'] = 'These additional fields will be 
 
 $_lang['setting_localizator_check_permissions'] = 'Check permissions';
 $_lang['setting_localizator_check_permissions_desc'] = 'Check permissions to edit localization';
+
+$_lang['setting_localizator_disabled_templates'] = 'Disable localization tab for templates';
+$_lang['setting_localizator_disabled_templates_desc'] = 'Comma-separated list of template IDs. The Localizator tab will not be shown for resources using these templates.';

--- a/core/components/localizator/lexicon/fr/setting.inc.php
+++ b/core/components/localizator/lexicon/fr/setting.inc.php
@@ -26,3 +26,6 @@ $_lang['setting_localizator_tv_fields_desc'] = 'Ces champs supplémentaires sero
 
 $_lang['setting_localizator_check_permissions'] = 'Vérifier les autorisations';
 $_lang['setting_localizator_check_permissions_desc'] = 'Vérifier les autorisations pour modifier la localisation';
+
+$_lang['setting_localizator_disabled_templates'] = 'Désactiver l’onglet de localisation pour les modèles';
+$_lang['setting_localizator_disabled_templates_desc'] = 'Liste d’ID de modèles séparés par des virgules. L’onglet Localizator ne sera pas affiché pour les ressources utilisant ces modèles.';

--- a/core/components/localizator/lexicon/ru/setting.inc.php
+++ b/core/components/localizator/lexicon/ru/setting.inc.php
@@ -32,3 +32,6 @@ $_lang['setting_localizator_tv_fields_desc'] = 'Указанные дополн�
 
 $_lang['setting_localizator_check_permissions'] = 'Проверять доступ на редактирование';
 $_lang['setting_localizator_check_permissions_desc'] = 'Проверять доступ на редактирование Локализаций ресурса';
+
+$_lang['setting_localizator_disabled_templates'] = 'Отключить вкладку локализации для шаблонов';
+$_lang['setting_localizator_disabled_templates_desc'] = 'Перечень ID шаблонов через запятую. Для ресурсов с этими шаблонами вкладка «Локализатор» не будет отображаться.';

--- a/core/components/localizator/model/localizator/localizatorresourcetvwrapper.class.php
+++ b/core/components/localizator/model/localizator/localizatorresourcetvwrapper.class.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Wrapper for modResource that returns pre-rendered TV values for localized TVs.
+ * Prevents double application of TV output (e.g. image basePath) when outputting
+ * via $_modx->resource.tvName in Fenom templates.
+ *
+ * @package localizator
+ */
+class LocalizatorResourceTVWrapper
+{
+    /** @var modResource */
+    protected $resource;
+    /** @var array TV name => already rendered output value */
+    protected $tvOutput = array();
+
+    /**
+     * @param modResource $resource
+     * @param array $tvOutput [ tvName => renderedValue, ... ]
+     */
+    public function __construct(modResource $resource, array $tvOutput = array())
+    {
+        $this->resource = $resource;
+        $this->tvOutput = $tvOutput;
+    }
+
+    /**
+     * Return pre-rendered value for localized TVs to avoid double path (e.g. image baseUrl).
+     *
+     * @param string $key TV name
+     * @return mixed
+     */
+    public function getTVValue($key)
+    {
+        if (isset($this->tvOutput[$key])) {
+            return $this->tvOutput[$key];
+        }
+        return $this->resource->getTVValue($key);
+    }
+
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array(array($this->resource, $name), $arguments);
+    }
+
+    public function __get($name)
+    {
+        return $this->resource->$name;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->resource->$name = $value;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->resource->$name);
+    }
+
+    public function __unset($name)
+    {
+        unset($this->resource->$name);
+    }
+}

--- a/core/components/localizator/processors/mgr/content/updatefromgrid.class.php
+++ b/core/components/localizator/processors/mgr/content/updatefromgrid.class.php
@@ -35,9 +35,14 @@ class localizatorContentUpdateFromGridProcessor extends localizatorContentUpdate
         $properties = $this->getProperties();
 
         foreach ($properties as $key => $value) {
-            if ($key == '_key') {
-                $key_value = explode(" ", $value);
-                $this->setProperty('key', $key_value[0]);
+            if ($key == '_key' && $value !== '' && $value !== null) {
+                // _key from grid can be display value like "English [en] (http_host)" — use key from brackets
+                if (preg_match('/\[([^\]]+)\]/', $value, $m)) {
+                    $this->setProperty('key', trim($m[1]));
+                } else {
+                    $key_value = explode(" ", $value);
+                    $this->setProperty('key', $key_value[0]);
+                }
             }
         }
 

--- a/core/components/localizator/processors/mgr/fields.class.php
+++ b/core/components/localizator/processors/mgr/fields.class.php
@@ -84,7 +84,12 @@ class localizatorFormProcessor extends modProcessor
                 'caption' => $this->modx->lexicon('localizator_keywords'),
             ),
         );
-        if (!in_array($class_key, array('modStaticResource', 'modSymLink', 'modWebLink'))) {
+        if (in_array($class_key, array('modWebLink', 'modSymLink'))) {
+            $resourcefields['content'] = array(
+                'inputTVtype' => 'number',
+                'caption' => $this->modx->lexicon('resource_content'),
+            );
+        } elseif ($class_key !== 'modStaticResource') {
             $resourcefields['content'] = array(
                 'inputTVtype' => $richtext ? 'richtext' : 'textarea',
             );


### PR DESCRIPTION
# Release 1.1.0-beta

Исправления по issues #3, #4, #5, #6, #7 и обновление версии до 1.1.0.

## Изменения

### #7 — Убрать console.log
- Удалена закомментированная строка `console.log` в `content.grid.js`, чтобы в консоли браузера не выводились сообщения при открытии окна редактирования.

### #6 — Неправильный ключ языка при редактировании
- В процессоре `updatefromgrid` поле `_key` из грида приходит в виде отображаемого значения вида `"English [en] (http_host)"`.
- Раньше в БД записывалось первое слово (`English`) вместо ключа.
- Теперь ключ извлекается из квадратных скобок (`[en]`). Если скобок нет — используется прежняя логика (первое слово).

**Файл:** `core/components/localizator/processors/mgr/content/updatefromgrid.class.php`

### #5 — Отключение вкладки локализации для шаблонов
- Добавлена системная настройка **localizator_disabled_templates**: список ID шаблонов через запятую.
- Для ресурсов с этими шаблонами вкладка «Локализатор» в форме редактирования не показывается.
- Лексиконы для настройки добавлены в ru, en, fr, be.

**Файлы:** `_build/data/transport.settings.php`, `plugin.localizator.php`, лексиконы `setting.inc.php`.

### #4 — Проблема с modWebLink/modSymLink (поле content)
- Поле «Ссылка» (content) снова отображается в форме локализации для ресурсов типа Ссылка и Симлинк — можно задавать разный ID цели для каждого языка.
- При сохранении самого ресурса в БД обновляется только запись языка по умолчанию; значения остальных языков, заданные во вкладке «Локализация», не перезаписываются.

**Файлы:** `core/components/localizator/processors/mgr/fields.class.php`, `plugin.localizator.php` (OnDocFormSave).

### #3 — Дублирование пути в TV при выводе через Fenom
- При выводе TV (например, картинки) через `$_modx->resource.img` путь дублировался: `assets/images/assets/images/news/img.jpg`.
- Причина: значение один раз рендерилось в плагине, затем при обращении к ресурсу снова применялся output типа (image), и basePath добавлялся повторно.
- Добавлена обёртка `LocalizatorResourceTVWrapper`: переопределён только `getTVValue()` — для локализованных TV возвращается уже отрендеренное значение, без повторного вызова output.

**Файлы:**  
`core/components/localizator/model/localizator/localizatorresourcetvwrapper.class.php` (новый),  
`plugin.localizator.php` (OnLoadWebDocument).

---

## Версия и сборка

- Версия: **1.1.0-beta** (`_build/build.config.php`).
- Changelog обновлён в `core/components/localizator/docs/changelog.txt`.

## Проверка

- Логика изменений согласована с описанными issues.
- Существующее поведение (modDocument, modStaticResource, плейсхолдеры, модификатор `locfield`) не менялось кроме указанных мест.